### PR TITLE
Replace @typescript-eslint/recommended-requiring-type-checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobuildlab/create-react-typescript-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Create a React Typescript App with configurations and linters",
   "homepage": "https://github.com/cobuildlab/create-react-typescript-app",
   "author": "",

--- a/template/.eslintrc.json
+++ b/template/.eslintrc.json
@@ -12,8 +12,8 @@
   "extends": [
     "airbnb-typescript",
     "airbnb/hooks",
+    "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "react-app",
     "plugin:jsx-a11y/recommended",
     "prettier",


### PR DESCRIPTION
Replace `@typescript-eslint/recommended-requiring-type-checking` with `eslint:recommended` in the linter configuration.

`recommended-requiring-type-checking` enables very strict rules about typings and displays linting errors almost everywhere when declaring variables with third-party libraries such as `styled-components` and `react-simple-state` that can return values of type `any`.

Replaced with `eslint:recommended` to add a bit of flexibility.